### PR TITLE
Add GitHub pages style sheet

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,27 @@
+<!-- start custom head snippets, customize with your own _includes/head-custom.html file -->
+
+<!-- Setup Google Analytics -->
+{% include head-custom-google-analytics.html %}
+
+<!-- You can set your favicon here -->
+<!-- link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}" -->
+<script>
+  function toggleWidth() {
+    if (document.querySelector("div.container-lg").style["max-width"]) {
+      document.querySelector("div.container-lg").style.maxWidth = null;
+      document.querySelector("button[name='toggle-table-width']").textContent = "Expand table";
+    } else {
+      document.querySelector("div.container-lg").style.maxWidth = "100%";
+      document.querySelector("button[name='toggle-table-width']").textContent = "Collapse table";
+    }
+  }
+  document.addEventListener("DOMContentLoaded", function(event) {
+    var el = document.querySelector('table');
+    var wrapper = document.createElement('div');
+    wrapper.setAttribute("id", "comparison-table");
+    el.parentNode.insertBefore(wrapper, el);
+    wrapper.appendChild(el);
+    document.getElementById("comparison-table").insertAdjacentHTML( 'beforebegin', '<button name="toggle-table-width" onclick="toggleWidth()">Expand table</button>' );
+  });
+</script>
+<!-- end custom head snippets -->

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,38 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+div#comparison-table {
+  max-height: 75vh;
+  overflow: auto;
+}
+
+table {
+  display: table !important;
+  text-align: left;
+  position: relative;
+}
+
+th {
+  background: white;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+th:first-child {
+  left: 0;
+  z-index: 3;
+}
+
+td:first-child {
+  background: white;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+div.container-lg > h1:nth-child(1) {
+  display: none;
+}


### PR DESCRIPTION
This adds a couple files to support a GitHub pages rendering of the site

These two files do a few things

* Makes the page width adjustable with a button so you can see more columns
* Changes the table height to 75% of the size of the viewport so you can see more rows
* Sticky the header row and the left-most column so you can always see the photo library name and the attribute name while you scroll horizontally or vertically

You can turn on GitHub pages along with this PR by

* going to https://github.com/meichthys/foss_photo_libraries/settings/pages
* Setting `Source` to `Deploy from a branch`
* Setting `Branch` to `main` and `/(root)` and then clicking `Save`

Once done, GitHub actions will build the site and it will be available at https://meichthys.github.io/foss_photo_libraries/

This solves a few problems with the current table as viewed through GitHub's repo rendering of the `readme.md`

* The table is too narrow to show all of the photo libraries
* The horizontal scrollbar is only at the bottom of the table so you have to scroll to the bottom to scroll right and left at which point you can't see the table header showing the name of the photo library
* The table is too tall so when you scroll down you can't see the photo library name
* When you scroll down the photo library name doesn't stay at the top of the table, it disappears
* Much of the page width is unused because of how GitHub renders a README. As a result you can't see that many columns at the same time

You can preview the GitHub pages rendering of this PR here, if you want to see what it looks like : https://gene1wood.github.io/foss_photo_libraries/