### PR TITLE
Update awesome selfhosted link to target "...#photo-galleries" instead of "#photo-and-video-galleries"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Tip: Hover over emoji for additional information (ðŸ”— link to related issue, ðŸ
 
 For links to other photo library projects, see:
 
-- [Awesome Self-Hosted](https://github.com/awesome-selfhosted/awesome-selfhosted#photo-and-video-galleries)
+- [Awesome Self-Hosted](https://github.com/awesome-selfhosted/awesome-selfhosted#photo-galleries)
 - [Awesome Privacy](https://github.com/pluja/awesome-privacy#photo-storage)
 
 An HTML version of this comparison table is here: https://meichthys.github.io/foss_photo_libraries/


### PR DESCRIPTION
The anchor "#photo-and-video-galleries" is invalid since the target file updated it to "#photo-galleries".